### PR TITLE
feat: Get rid of double definition of FileSystemWrapper

### DIFF
--- a/tests/meta_perf/run_performance_tests.cpp
+++ b/tests/meta_perf/run_performance_tests.cpp
@@ -6,39 +6,16 @@
 
 #include "arrow/io/file.h"
 #include "arrow/result.h"
+#include "iceberg/common/fs/filesystem_wrapper.h"
 #include "iceberg/tea_scan.h"
 
 namespace {
+
+using namespace iceberg;
 struct Metrics {
   uint64_t requests = 0;
   uint64_t bytes_read = 0;
   uint64_t files_opened = 0;
-};
-
-class InputFileWrapper : public arrow::io::RandomAccessFile {
- public:
-  explicit InputFileWrapper(std::shared_ptr<arrow::io::RandomAccessFile> file) : file_(file) {}
-
-  arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
-    return file_->ReadAt(position, nbytes, out);
-  }
-
-  arrow::Status Close() override { return file_->Close(); }
-
-  bool closed() const override { return file_->closed(); }
-
-  arrow::Result<int64_t> Tell() const override { return file_->Tell(); }
-
-  arrow::Result<int64_t> Read(int64_t nbytes, void* out) override { return file_->Read(nbytes, out); }
-
-  arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override { return file_->Read(nbytes); }
-
-  arrow::Status Seek(int64_t position) override { return file_->Seek(position); }
-
-  arrow::Result<int64_t> GetSize() override { return file_->GetSize(); }
-
- private:
-  std::shared_ptr<arrow::io::RandomAccessFile> file_;
 };
 
 class LoggingInputFile : public InputFileWrapper {
@@ -68,11 +45,6 @@ class LoggingInputFile : public InputFileWrapper {
   }
 
   std::shared_ptr<Metrics> metrics_;
-};
-
-class FileSystemWrapper : public arrow::fs::SubTreeFileSystem {
- public:
-  explicit FileSystemWrapper(std::shared_ptr<arrow::fs::FileSystem> fs) : arrow::fs::SubTreeFileSystem("", fs) {}
 };
 
 class LoggingFileSystem : public FileSystemWrapper {

--- a/tests/tea_scan_test.cpp
+++ b/tests/tea_scan_test.cpp
@@ -7,16 +7,12 @@
 #include <fstream>
 
 #include "gtest/gtest.h"
+#include "iceberg/common/fs/filesystem_wrapper.h"
 #include "iceberg/experimental_representations.h"
 #include "iceberg/type.h"
 
 namespace iceberg {
 namespace {
-
-class FileSystemWrapper : public arrow::fs::SubTreeFileSystem {
- public:
-  explicit FileSystemWrapper(std::shared_ptr<arrow::fs::FileSystem> fs) : arrow::fs::SubTreeFileSystem("", fs) {}
-};
 
 class ReplacingFilesystem : public FileSystemWrapper {
  public:


### PR DESCRIPTION
Get rid of double definition of FileSystemWrapper