### PR TITLE
fix: set use_reader_schema in AllEntriesStream constructor

### DIFF
--- a/iceberg/tea_scan.cpp
+++ b/iceberg/tea_scan.cpp
@@ -346,7 +346,8 @@ std::optional<ManifestEntry> AllEntriesStream::ReadNext() {
       throw std::runtime_error(std::string(__PRETTY_FUNCTION__) + ": failed to parse partition_spec_id " +
                                std::to_string(current_manifest_file.partition_spec_id));
     }
-    Manifest manifest = ice_tea::ReadManifestEntries(entries_content, maybe_partition_spec.value(), config_);
+    Manifest manifest =
+        ice_tea::ReadManifestEntries(entries_content, maybe_partition_spec.value(), config_, use_avro_reader_schema_);
     // it is impossible to construct queue from iterators before C++23
     entries_for_current_manifest_file_ = std::queue<ManifestEntry>(std::deque<ManifestEntry>(
         std::make_move_iterator(manifest.entries.begin()), std::make_move_iterator(manifest.entries.end())));

--- a/iceberg/tea_scan.h
+++ b/iceberg/tea_scan.h
@@ -112,7 +112,8 @@ class AllEntriesStream : public IcebergEntriesStream {
         manifest_files_(std::move(manifest_files)),
         partition_specs_(partition_specs),
         schema_(schema),
-        config_(config) {}
+        config_(config),
+        use_avro_reader_schema_(use_reader_schema) {}
 
   static std::shared_ptr<AllEntriesStream> Make(std::shared_ptr<arrow::fs::FileSystem> fs,
                                                 const std::string& manifest_list_path, bool use_reader_schema,
@@ -137,6 +138,7 @@ class AllEntriesStream : public IcebergEntriesStream {
   std::shared_ptr<iceberg::Schema> schema_;
   const std::vector<std::shared_ptr<PartitionSpec>> partition_specs_;
   ManifestEntryDeserializerConfig config_;
+  bool use_avro_reader_schema_ = false;
 };
 
 arrow::Result<ScanMetadata> GetScanMetadata(IcebergEntriesStream& entries_stream,


### PR DESCRIPTION
#84 introduced `use_avro_reader_schema` flag which is not used in AllEntriesStream. This PR sets this flag in AllEntriesStream 