### PR TITLE
fix: empty table handling

### DIFF
--- a/iceberg/table_metadata.cpp
+++ b/iceberg/table_metadata.cpp
@@ -853,6 +853,9 @@ TableMetadataV2::TableMetadataV2(std::string table_uuid_, std::string location_,
       default_sort_order_id(default_sort_order_id_),
       refs(std::move(refs_)),
       statistics(std::move(statistics_)) {
+  if (current_snapshot_id == -1) {
+    current_snapshot_id = std::nullopt;
+  }
   DefaultChecker default_checker;
   default_checker.Check(*this);
 }
@@ -877,20 +880,8 @@ std::string TableMetadataV2::GetCurrentManifestListPathOrFail() const {
 }
 
 std::shared_ptr<Schema> TableMetadataV2::GetCurrentSchema() const {
-  Ensure(current_snapshot_id.has_value() && !snapshots.empty(), std::string(__FUNCTION__) + ": no current snapshot");
-
-  std::optional<int64_t> schema_id;
-  for (const auto& snapshot : snapshots) {
-    if (snapshot->snapshot_id == current_snapshot_id.value()) {
-      Ensure(snapshot->schema_id.has_value(), std::string(__FUNCTION__) + ": no schema id");
-
-      schema_id = snapshot->schema_id.value();
-    }
-  }
-  Ensure(schema_id.has_value(), std::string(__FUNCTION__) + ": no current snapshot");
-
   for (const auto& schema : schemas) {
-    if (schema->SchemaId() == schema_id.value()) {
+    if (schema->SchemaId() == current_schema_id) {
       return schema;
     }
   }

--- a/iceberg/table_metadata.cpp
+++ b/iceberg/table_metadata.cpp
@@ -853,6 +853,11 @@ TableMetadataV2::TableMetadataV2(std::string table_uuid_, std::string location_,
       default_sort_order_id(default_sort_order_id_),
       refs(std::move(refs_)),
       statistics(std::move(statistics_)) {
+  // https://iceberg.apache.org/spec/#assignment-of-snapshot-ids-and-current-snapshot-id
+  // Java writes -1 for "no current snapshot" with V1 and V2 tables and considers this equivalent to omitted or null.
+  // This has never been formalized in the spec, but for compatibility, other implementations can accept -1 as null.
+  // Java will no longer write -1 and will use null for "no current snapshot" for all tables with a version greater than
+  // or equal to V3
   if (current_snapshot_id == -1) {
     current_snapshot_id = std::nullopt;
   }

--- a/tests/table_metadata_test.cpp
+++ b/tests/table_metadata_test.cpp
@@ -765,4 +765,53 @@ TEST(Metadata, Statistics) {
   EXPECT_EQ(statistics.key_metadata.has_value(), false);
 }
 
+TEST(Metadata, EmptyTable) {
+  std::ifstream input("warehouse/empty/empty/metadata/00000-80089c7c-cfe3-4279-a864-ef65495ba43b.metadata.json");
+
+  auto metadata = ice_tea::ReadTableMetadataV2(input);
+  ASSERT_TRUE(metadata);
+
+  EXPECT_EQ(metadata->table_uuid, "83d399af-a71f-4a31-8625-a39c7e97953e");
+  EXPECT_EQ(metadata->location, "s3://warehouse/empty/empty");
+  EXPECT_EQ(metadata->last_sequence_number, 0);
+  EXPECT_EQ(metadata->last_column_id, 2);
+
+  EXPECT_FALSE(metadata->current_snapshot_id.has_value());
+
+  EXPECT_TRUE(metadata->snapshots.empty());
+
+  EXPECT_EQ(metadata->current_schema_id, 0);
+  ASSERT_EQ(metadata->schemas.size(), 1);
+
+  auto schema = metadata->GetCurrentSchema();
+  ASSERT_TRUE(schema);
+  EXPECT_EQ(schema->SchemaId(), 0);
+
+  const auto& columns = schema->Columns();
+  ASSERT_EQ(columns.size(), 2);
+
+  EXPECT_EQ(columns[0].field_id, 1);
+  EXPECT_EQ(columns[0].name, "a");
+  EXPECT_FALSE(columns[0].is_required);
+  ASSERT_TRUE(columns[0].type->IsPrimitiveType());
+  EXPECT_EQ(columns[0].type->TypeId(), iceberg::TypeID::kLong);
+
+  EXPECT_EQ(columns[1].field_id, 2);
+  EXPECT_EQ(columns[1].name, "b");
+  EXPECT_FALSE(columns[1].is_required);
+  ASSERT_TRUE(columns[1].type->IsPrimitiveType());
+  EXPECT_EQ(columns[1].type->TypeId(), iceberg::TypeID::kLong);
+
+  ASSERT_EQ(metadata->partition_specs.size(), 1);
+  EXPECT_EQ(metadata->partition_specs[0]->spec_id, 0);
+  EXPECT_TRUE(metadata->partition_specs[0]->fields.empty());
+
+  ASSERT_EQ(metadata->sort_orders.size(), 1);
+  EXPECT_EQ(metadata->sort_orders[0]->order_id, 0);
+  EXPECT_TRUE(metadata->sort_orders[0]->fields.empty());
+  EXPECT_EQ(metadata->default_sort_order_id, 0);
+
+  EXPECT_EQ(metadata->properties.at("write.format.default"), "PARQUET");
+}
+
 }  // namespace iceberg


### PR DESCRIPTION
We assumed that a table must contain at least one snapshot to be readable. In reality, a table may not contain any snapshots and be interpreted as empty.
