### PR TITLE
Extend .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ compile_commands.json
 /.vscode/
 /out/
 /_build/
+/_deps/


### PR DESCRIPTION
Add _deps folder in .gitignore because you may use it folder for building