### PR TITLE
feat: support reading deletion vectors in file reader

### DIFF
--- a/iceberg/common/fs/CMakeLists.txt
+++ b/iceberg/common/fs/CMakeLists.txt
@@ -8,7 +8,8 @@ target_link_libraries(iceberg_common_fs PUBLIC Arrow::arrow_static absl::base)
 
 add_executable(
   iceberg_common_fs_test
-  ut/url_test.cpp)
+  ut/url_test.cpp
+  ut/file_reader_provider_test.cpp)
 
-target_link_libraries(iceberg_common_fs_test PRIVATE gtest_main iceberg_common_fs)
+target_link_libraries(iceberg_common_fs_test PRIVATE gtest_main iceberg_common_fs iceberg-cpp iceberg_test_utils)
 target_include_directories(iceberg_common_fs_test PUBLIC ${CMAKE_SOURCE_DIR})

--- a/iceberg/common/fs/file_reader_provider.h
+++ b/iceberg/common/fs/file_reader_provider.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
 #include "arrow/result.h"
+#include "iceberg/deletion_vector.h"
 #include "parquet/arrow/reader.h"
 
 namespace iceberg {
@@ -11,6 +13,8 @@ namespace iceberg {
 class IFileReaderProvider {
  public:
   virtual arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> OpenParquet(const std::string& url) const = 0;
+  virtual arrow::Result<std::shared_ptr<DeletionVector>> OpenDeletionVector(const std::string& path, int64_t offset,
+                                                                            int64_t length) const = 0;
 
   virtual ~IFileReaderProvider() = default;
 };

--- a/iceberg/common/fs/file_reader_provider_impl.h
+++ b/iceberg/common/fs/file_reader_provider_impl.h
@@ -31,6 +31,25 @@ class FileReaderProvider : public IFileReaderProvider {
     return reader_builder.Build();
   }
 
+  arrow::Result<std::shared_ptr<DeletionVector>> OpenDeletionVector(const std::string& path, int64_t offset,
+                                                                    int64_t length) const override {
+    ARROW_ASSIGN_OR_RAISE(auto input_file, opener_(path));
+    ARROW_ASSIGN_OR_RAISE(auto footer, PuffinFile::ReadFooter(input_file));
+
+    auto deserialized_footer = footer.GetDeserializedFooter();
+    auto it =
+        std::find_if(deserialized_footer.blobs.begin(), deserialized_footer.blobs.end(),
+                     [offset, length](const auto& blob) { return blob.offset == offset && blob.length == length; });
+    if (it == deserialized_footer.blobs.end()) {
+      return arrow::Status::IOError("Deletion vector blob not found at offset ", offset);
+    }
+    ARROW_ASSIGN_OR_RAISE(auto buffer, input_file->ReadAt(offset, length));
+
+    // TODO(MeT3ger): reorganize interface to avoid redundant copies of blob data
+    std::string blob_data(reinterpret_cast<const char*>(buffer->data()), buffer->size());
+    return std::make_shared<DeletionVector>(*it, std::move(blob_data));
+  }
+
  private:
   RawOpener opener_;
 };

--- a/iceberg/common/fs/file_reader_provider_impl.h
+++ b/iceberg/common/fs/file_reader_provider_impl.h
@@ -10,6 +10,7 @@
 #include "arrow/status.h"
 #include "iceberg/common/fs/file_reader_provider.h"
 #include "iceberg/common/fs/filesystem_provider.h"
+#include "iceberg/deletion_vector.h"
 #include "iceberg/puffin.h"
 #include "iceberg/tea_scan.h"
 #include "parquet/arrow/reader.h"

--- a/iceberg/common/fs/ut/file_reader_provider_test.cpp
+++ b/iceberg/common/fs/ut/file_reader_provider_test.cpp
@@ -1,0 +1,65 @@
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <roaring.hh>
+
+#include "gtest/gtest.h"
+#include "iceberg/common/fs/file_reader_provider_impl.h"
+#include "iceberg/common/fs/filesystem_provider_impl.h"
+#include "iceberg/deletion_vector.h"
+#include "iceberg/puffin.h"
+#include "iceberg/test_utils/scoped_temp_dir.h"
+
+namespace iceberg {
+namespace {
+
+TEST(FileReaderProviderTest, OpenDeletionVector) {
+  PuffinFile::Footer::BlobMetadata dummy_meta;
+
+  roaring::Roaring64Map bitmap;
+  bitmap.add(static_cast<uint64_t>(100));
+
+  dummy_meta.properties[std::string(properties_names::kCardinality)] = std::to_string(bitmap.cardinality());
+  dummy_meta.properties[std::string(properties_names::kReferencedDataFile)] = "data.parquet";
+  dummy_meta.type = std::string(DeletionVector::kBlobType);
+
+  DeletionVector dv(dummy_meta, std::move(bitmap));
+  std::string blob_data = dv.GetBlob();
+  auto properties = dv.GetProperties();
+
+  PuffinFileBuilder builder;
+  builder.SetSnapshotId(1);
+  builder.SetSequenceNumber(1);
+  builder.AppendBlob(blob_data, properties, {}, std::string(DeletionVector::kBlobType));
+
+  PuffinFile puffin_file = std::move(builder).Build();
+  std::string payload = puffin_file.GetPayload();
+
+  ScopedTempDir dir;
+  std::string filename = dir.path() / "test.puffin";
+  {
+    std::ofstream out(filename, std::ios::binary);
+    out.write(payload.data(), payload.size());
+  }
+
+  auto footer = puffin_file.GetFooter().GetDeserializedFooter();
+  ASSERT_EQ(footer.blobs.size(), 1);
+  auto blob_meta = footer.blobs[0];
+
+  std::map<std::string, std::shared_ptr<IFileSystemGetter>> getters;
+  getters.emplace("file", std::make_shared<LocalFileSystemGetter>());
+
+  auto fs_provider = std::make_shared<FileSystemProvider>(std::move(getters));
+  auto provider = MakeFileReaderProvider(fs_provider);
+
+  auto opened_dv_res = provider->OpenDeletionVector("file://" + filename, blob_meta.offset, blob_meta.length);
+  ASSERT_TRUE(opened_dv_res.ok()) << opened_dv_res.status().ToString();
+  auto opened_dv = opened_dv_res.ValueOrDie();
+
+  EXPECT_TRUE(opened_dv->Contains(100));
+  EXPECT_FALSE(opened_dv->Contains(10));
+  EXPECT_EQ(opened_dv->Cardinality(), 1);
+}
+
+}  // namespace
+}  // namespace iceberg


### PR DESCRIPTION
This PR extends the Iceberg file reader to support reading deletion vectors.