### PR TITLE
refactoring: file reader provider

### DIFF
--- a/iceberg/common/fs/file_reader_provider.h
+++ b/iceberg/common/fs/file_reader_provider.h
@@ -10,7 +10,7 @@ namespace iceberg {
 
 class IFileReaderProvider {
  public:
-  virtual arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> OpenParquet(const std::string& url) const = 0;                                                                         int64_t length) const = 0;
+  virtual arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> OpenParquet(const std::string& url) const = 0;
 
   virtual ~IFileReaderProvider() = default;
 };

--- a/iceberg/common/fs/file_reader_provider.h
+++ b/iceberg/common/fs/file_reader_provider.h
@@ -3,13 +3,14 @@
 #include <memory>
 #include <string>
 
+#include "arrow/result.h"
 #include "parquet/arrow/reader.h"
 
 namespace iceberg {
 
 class IFileReaderProvider {
  public:
-  virtual arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> Open(const std::string& url) const = 0;
+  virtual arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> OpenParquet(const std::string& url) const = 0;                                                                         int64_t length) const = 0;
 
   virtual ~IFileReaderProvider() = default;
 };

--- a/iceberg/common/fs/file_reader_provider_impl.h
+++ b/iceberg/common/fs/file_reader_provider_impl.h
@@ -1,28 +1,29 @@
 #pragma once
 
+#include <algorithm>
+#include <functional>
 #include <memory>
 #include <string>
 
+#include "arrow/io/interfaces.h"
+#include "arrow/result.h"
 #include "arrow/status.h"
 #include "iceberg/common/fs/file_reader_provider.h"
 #include "iceberg/common/fs/filesystem_provider.h"
+#include "iceberg/puffin.h"
+#include "iceberg/tea_scan.h"
 #include "parquet/arrow/reader.h"
 
 namespace iceberg {
 
 class FileReaderProvider : public IFileReaderProvider {
  public:
-  explicit FileReaderProvider(std::shared_ptr<IFileSystemProvider> fs_provider) : fs_provider_(fs_provider) {}
+  using RawOpener = std::function<arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>>(const std::string&)>;
 
-  arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> Open(const std::string& url) const override {
-    ARROW_ASSIGN_OR_RAISE(auto fs, fs_provider_->GetFileSystem(url));
+  explicit FileReaderProvider(RawOpener opener) : opener_(std::move(opener)) {}
 
-    if (url.find("://") == std::string::npos) {
-      return arrow::Status::ExecutionError("FileReaderProvider: file ", url, " does not contain schema");
-    }
-
-    std::string path = url.substr(url.find("://") + 3);
-    ARROW_ASSIGN_OR_RAISE(auto input_file, fs->OpenInputFile(path));
+  arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> OpenParquet(const std::string& url) const override {
+    ARROW_ASSIGN_OR_RAISE(auto input_file, opener_(url));
 
     parquet::arrow::FileReaderBuilder reader_builder;
     ARROW_RETURN_NOT_OK(reader_builder.Open(input_file));
@@ -31,7 +32,21 @@ class FileReaderProvider : public IFileReaderProvider {
   }
 
  private:
-  std::shared_ptr<IFileSystemProvider> fs_provider_;
+  RawOpener opener_;
 };
+
+inline std::shared_ptr<IFileReaderProvider> MakeFileReaderProvider(std::shared_ptr<IFileSystemProvider> fs_provider) {
+  return std::make_shared<FileReaderProvider>([fs_provider = std::move(fs_provider)](const std::string& url)
+                                                  -> arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> {
+    ARROW_ASSIGN_OR_RAISE(auto fs, fs_provider->GetFileSystem(url));
+
+    if (url.find("://") == std::string::npos) {
+      return arrow::Status::ExecutionError("FileReaderProvider: file ", url, " does not contain schema");
+    }
+
+    std::string path = url.substr(url.find("://") + 3);
+    return fs->OpenInputFile(path);
+  });
+}
 
 }  // namespace iceberg

--- a/iceberg/streams/iceberg/equality_delete_applier.h
+++ b/iceberg/streams/iceberg/equality_delete_applier.h
@@ -81,7 +81,7 @@ class EqualityDeleteApplier : public IcebergStream {
     bool can_reuse_state = current_state_.has_value() && (*current_state_ == batch->GetPartition());
     if (!can_reuse_state) {
       auto open_file_lambda = [file_reader_provider = this->file_reader_provider_](const std::string& path) {
-        return file_reader_provider->Open(path);
+        return file_reader_provider->OpenParquet(path);
       };
 
       equality_delete_handler_.emplace(open_file_lambda, eq_del_config_, logger_);

--- a/iceberg/streams/iceberg/file_reader_builder.h
+++ b/iceberg/streams/iceberg/file_reader_builder.h
@@ -68,7 +68,7 @@ class FileReaderBuilder : public DataScanner::IIcebergStreamBuilder {
 
  private:
   std::shared_ptr<parquet::arrow::FileReader> MakeArrowReader(const std::string& path) {
-    auto input_file = iceberg::ValueSafe(file_reader_provider_->Open(path));
+    auto input_file = iceberg::ValueSafe(file_reader_provider_->OpenParquet(path));
     return input_file;
   }
 

--- a/iceberg/streams/iceberg/positional_delete_applier.h
+++ b/iceberg/streams/iceberg/positional_delete_applier.h
@@ -81,7 +81,7 @@ class PositionalDeleteApplier : public IcebergStream {
       }
 
       auto open_file_lambda = [file_reader_provider = this->file_reader_provider_](const std::string& path) {
-        auto result = iceberg::ValueSafe(file_reader_provider->Open(path));
+        auto result = iceberg::ValueSafe(file_reader_provider->OpenParquet(path));
 
         return result;
       };

--- a/iceberg/streams/main.cpp
+++ b/iceberg/streams/main.cpp
@@ -220,7 +220,7 @@ int main(int argc, char** argv) {
     auto data_stream = iceberg::IcebergScanBuilder::MakeIcebergStream(
         meta_stream, pos_del_info, std::make_shared<iceberg::EqualityDeletes>(std::move(eq_del_info)),
         std::move(eq_del_config), nullptr, nullptr, *table_metadata->GetCurrentSchema(), {1},
-        std::make_shared<iceberg::FileReaderProvider>(fs_provider), std::move(schema_name_mapping));
+        iceberg::MakeFileReaderProvider(fs_provider), std::move(schema_name_mapping));
 
     while (true) {
       auto batch = data_stream->ReadNext();

--- a/iceberg/streams/ut/equality_delete_applier_test.cpp
+++ b/iceberg/streams/ut/equality_delete_applier_test.cpp
@@ -71,7 +71,7 @@ class EqualityDeleteApplierTest : public ::testing::Test {
     auto positional_delete_applier =
         std::make_shared<EqualityDeleteApplier>(input_stream, std::make_shared<EqualityDeletes>(std::move(info)), cfg,
                                                 std::make_shared<FieldIdMapper>(std::move(field_id_to_name)),
-                                                std::make_shared<FileReaderProvider>(fs_provider), counting_logger_);
+                                                MakeFileReaderProvider(fs_provider), counting_logger_);
 
     std::vector<std::shared_ptr<IcebergBatch>> result_batches;
     while (true) {

--- a/iceberg/streams/ut/file_reader_builder_test.cpp
+++ b/iceberg/streams/ut/file_reader_builder_test.cpp
@@ -40,7 +40,7 @@ TEST_F(FileReaderBuilderTest, Trivial) {
   auto field_id_mapper = std::make_shared<FieldIdMapper>(std::map<int, std::string>{{1, "col1"}, {3, "col123"}});
 
   FileReaderBuilder file_reader_builder(field_ids_to_retrieve, equality_deletes_, field_id_mapper,
-                                        std::make_shared<FileReaderProvider>(fs_provider_), nullptr, nullptr,
+                                        MakeFileReaderProvider(fs_provider_), nullptr, nullptr,
                                         std::nullopt, std::make_shared<const std::map<int, Literal>>());
 
   auto col1_data = OptionalVector<int64_t>{1, 2, 3, 4};
@@ -74,7 +74,7 @@ TEST_F(FileReaderBuilderTest, RowFilter) {
   auto row_filter = std::make_shared<PassThroughFilter>(std::vector<int32_t>{3, 2});
 
   FileReaderBuilder file_reader_builder(field_ids_to_retrieve, equality_deletes_, field_id_mapper,
-                                        std::make_shared<FileReaderProvider>(fs_provider_), nullptr, row_filter,
+                                        MakeFileReaderProvider(fs_provider_), nullptr, row_filter,
                                         std::nullopt, std::make_shared<const std::map<int, Literal>>());
 
   auto col1_data = OptionalVector<int32_t>{1, 2, 3, 4};
@@ -111,7 +111,7 @@ TEST_F(FileReaderBuilderTest, SchemaNameMapping) {
       " { \"field-id\": 1, \"names\": [\"xxx\"] } ]";
 
   FileReaderBuilder file_reader_builder(
-      field_ids_to_retrieve, equality_deletes_, field_id_mapper, std::make_shared<FileReaderProvider>(fs_provider_),
+      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_),
       nullptr, nullptr, SchemaNameMapper(schema_name_mapping), std::make_shared<const std::map<int, Literal>>());
 
   auto col1_data = OptionalVector<int32_t>{1, 2, 3, 4};
@@ -144,7 +144,7 @@ TEST_F(FileReaderBuilderTest, FieldIdFirst) {
       " { \"field-id\": 2, \"names\": [\"xxx\"] } ]";
 
   FileReaderBuilder file_reader_builder(
-      field_ids_to_retrieve, equality_deletes_, field_id_mapper, std::make_shared<FileReaderProvider>(fs_provider_),
+      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_),
       nullptr, nullptr, SchemaNameMapper(schema_name_mapping), std::make_shared<const std::map<int, Literal>>());
 
   auto col1_data = OptionalVector<int32_t>{1, 2, 3, 4};
@@ -176,7 +176,7 @@ TEST_F(FileReaderBuilderTest, FieldIDsAreNotInjective) {
       " { \"field-id\": 2, \"names\": [\"xxx\"] } ]";
 
   FileReaderBuilder file_reader_builder(
-      field_ids_to_retrieve, equality_deletes_, field_id_mapper, std::make_shared<FileReaderProvider>(fs_provider_),
+      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_),
       nullptr, nullptr, SchemaNameMapper(schema_name_mapping), std::make_shared<const std::map<int, Literal>>());
 
   auto col1_data = OptionalVector<int32_t>{1, 2, 3, 4};
@@ -203,7 +203,7 @@ TEST_F(FileReaderBuilderTest, SchemaNameMappingMissingColumn) {
       " { \"field-id\": 1, \"names\": [\"xxx\"] } ]";
 
   FileReaderBuilder file_reader_builder(
-      field_ids_to_retrieve, equality_deletes_, field_id_mapper, std::make_shared<FileReaderProvider>(fs_provider_),
+      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_),
       nullptr, nullptr, SchemaNameMapper(schema_name_mapping), std::make_shared<const std::map<int, Literal>>());
 
   auto col1_data = OptionalVector<int32_t>{1, 2, 3, 4};
@@ -234,7 +234,7 @@ TEST_F(FileReaderBuilderTest, SchemaNameMappingWithArray) {
       "[ { \"field-id\": 1, \"names\": [\"xxx\"], \"fields\": [ { \"field-id\": 3, \"names\": [\"element\"] } ] } ]";
 
   FileReaderBuilder file_reader_builder(
-      field_ids_to_retrieve, equality_deletes_, field_id_mapper, std::make_shared<FileReaderProvider>(fs_provider_),
+      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_),
       nullptr, nullptr, SchemaNameMapper(schema_name_mapping), std::make_shared<const std::map<int, Literal>>());
 
   ArrayContainer col1_data = {
@@ -276,7 +276,7 @@ TEST_F(FileReaderBuilderTest, DefaultValue) {
   auto field_id_mapper = std::make_shared<FieldIdMapper>(std::map<int, std::string>{{1, "col1"}, {2, "col2"}});
 
   FileReaderBuilder file_reader_builder(
-      field_ids_to_retrieve, equality_deletes_, field_id_mapper, std::make_shared<FileReaderProvider>(fs_provider_),
+      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_),
       nullptr, nullptr, std::nullopt,
       std::make_shared<const std::map<int, Literal>>(
           std::map<int, Literal>{{2, Literal(std::make_shared<arrow::Int32Scalar>(10))}}));
@@ -306,7 +306,7 @@ TEST_F(FileReaderBuilderTest, ColumnFirst) {
   auto field_id_mapper = std::make_shared<FieldIdMapper>(std::map<int, std::string>{{1, "col1"}, {2, "col2"}});
 
   FileReaderBuilder file_reader_builder(field_ids_to_retrieve, equality_deletes_, field_id_mapper,
-                                        std::make_shared<FileReaderProvider>(fs_provider_), nullptr, nullptr,
+                                        MakeFileReaderProvider(fs_provider_), nullptr, nullptr,
                                         std::nullopt,
                                         std::make_shared<const std::map<int, Literal>>(std::map<int, Literal>{
                                             {1, Literal(std::make_shared<arrow::Int32Scalar>(2))},
@@ -342,7 +342,7 @@ TEST_F(FileReaderBuilderTest, SchemaNameMappingFirst) {
       " { \"field-id\": 1, \"names\": [\"xxx\"] } ]";
 
   FileReaderBuilder file_reader_builder(field_ids_to_retrieve, equality_deletes_, field_id_mapper,
-                                        std::make_shared<FileReaderProvider>(fs_provider_), nullptr, nullptr,
+                                        MakeFileReaderProvider(fs_provider_), nullptr, nullptr,
                                         SchemaNameMapper(schema_name_mapping),
                                         std::make_shared<const std::map<int, Literal>>(std::map<int, Literal>{
                                             {1, Literal(std::make_shared<arrow::Int32Scalar>(2))},
@@ -377,7 +377,7 @@ TEST_F(FileReaderBuilderTest, Combination) {
   const std::string schema_name_mapping = "[ { \"field-id\": 2, \"names\": [\"xxx\"] } ]";
 
   FileReaderBuilder file_reader_builder(field_ids_to_retrieve, equality_deletes_, field_id_mapper,
-                                        std::make_shared<FileReaderProvider>(fs_provider_), nullptr, nullptr,
+                                        MakeFileReaderProvider(fs_provider_), nullptr, nullptr,
                                         SchemaNameMapper(schema_name_mapping),
                                         std::make_shared<const std::map<int, Literal>>(std::map<int, Literal>{
                                             {1, Literal(std::make_shared<arrow::Int32Scalar>(2))},

--- a/iceberg/streams/ut/file_reader_builder_test.cpp
+++ b/iceberg/streams/ut/file_reader_builder_test.cpp
@@ -40,8 +40,8 @@ TEST_F(FileReaderBuilderTest, Trivial) {
   auto field_id_mapper = std::make_shared<FieldIdMapper>(std::map<int, std::string>{{1, "col1"}, {3, "col123"}});
 
   FileReaderBuilder file_reader_builder(field_ids_to_retrieve, equality_deletes_, field_id_mapper,
-                                        MakeFileReaderProvider(fs_provider_), nullptr, nullptr,
-                                        std::nullopt, std::make_shared<const std::map<int, Literal>>());
+                                        MakeFileReaderProvider(fs_provider_), nullptr, nullptr, std::nullopt,
+                                        std::make_shared<const std::map<int, Literal>>());
 
   auto col1_data = OptionalVector<int64_t>{1, 2, 3, 4};
   auto col2_data = OptionalVector<int32_t>{1, 2, 3, 4};
@@ -74,8 +74,8 @@ TEST_F(FileReaderBuilderTest, RowFilter) {
   auto row_filter = std::make_shared<PassThroughFilter>(std::vector<int32_t>{3, 2});
 
   FileReaderBuilder file_reader_builder(field_ids_to_retrieve, equality_deletes_, field_id_mapper,
-                                        MakeFileReaderProvider(fs_provider_), nullptr, row_filter,
-                                        std::nullopt, std::make_shared<const std::map<int, Literal>>());
+                                        MakeFileReaderProvider(fs_provider_), nullptr, row_filter, std::nullopt,
+                                        std::make_shared<const std::map<int, Literal>>());
 
   auto col1_data = OptionalVector<int32_t>{1, 2, 3, 4};
   auto col2_data = OptionalVector<int32_t>{5, 6, 7, 8};
@@ -111,8 +111,8 @@ TEST_F(FileReaderBuilderTest, SchemaNameMapping) {
       " { \"field-id\": 1, \"names\": [\"xxx\"] } ]";
 
   FileReaderBuilder file_reader_builder(
-      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_),
-      nullptr, nullptr, SchemaNameMapper(schema_name_mapping), std::make_shared<const std::map<int, Literal>>());
+      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_), nullptr, nullptr,
+      SchemaNameMapper(schema_name_mapping), std::make_shared<const std::map<int, Literal>>());
 
   auto col1_data = OptionalVector<int32_t>{1, 2, 3, 4};
   auto col2_data = OptionalVector<int32_t>{5, 6, 7, 8};
@@ -144,8 +144,8 @@ TEST_F(FileReaderBuilderTest, FieldIdFirst) {
       " { \"field-id\": 2, \"names\": [\"xxx\"] } ]";
 
   FileReaderBuilder file_reader_builder(
-      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_),
-      nullptr, nullptr, SchemaNameMapper(schema_name_mapping), std::make_shared<const std::map<int, Literal>>());
+      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_), nullptr, nullptr,
+      SchemaNameMapper(schema_name_mapping), std::make_shared<const std::map<int, Literal>>());
 
   auto col1_data = OptionalVector<int32_t>{1, 2, 3, 4};
   auto col2_data = OptionalVector<int32_t>{5, 6, 7, 8};
@@ -176,8 +176,8 @@ TEST_F(FileReaderBuilderTest, FieldIDsAreNotInjective) {
       " { \"field-id\": 2, \"names\": [\"xxx\"] } ]";
 
   FileReaderBuilder file_reader_builder(
-      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_),
-      nullptr, nullptr, SchemaNameMapper(schema_name_mapping), std::make_shared<const std::map<int, Literal>>());
+      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_), nullptr, nullptr,
+      SchemaNameMapper(schema_name_mapping), std::make_shared<const std::map<int, Literal>>());
 
   auto col1_data = OptionalVector<int32_t>{1, 2, 3, 4};
   auto col2_data = OptionalVector<int32_t>{5, 6, 7, 8};
@@ -203,8 +203,8 @@ TEST_F(FileReaderBuilderTest, SchemaNameMappingMissingColumn) {
       " { \"field-id\": 1, \"names\": [\"xxx\"] } ]";
 
   FileReaderBuilder file_reader_builder(
-      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_),
-      nullptr, nullptr, SchemaNameMapper(schema_name_mapping), std::make_shared<const std::map<int, Literal>>());
+      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_), nullptr, nullptr,
+      SchemaNameMapper(schema_name_mapping), std::make_shared<const std::map<int, Literal>>());
 
   auto col1_data = OptionalVector<int32_t>{1, 2, 3, 4};
   auto col2_data = OptionalVector<int32_t>{5, 6, 7, 8};
@@ -234,8 +234,8 @@ TEST_F(FileReaderBuilderTest, SchemaNameMappingWithArray) {
       "[ { \"field-id\": 1, \"names\": [\"xxx\"], \"fields\": [ { \"field-id\": 3, \"names\": [\"element\"] } ] } ]";
 
   FileReaderBuilder file_reader_builder(
-      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_),
-      nullptr, nullptr, SchemaNameMapper(schema_name_mapping), std::make_shared<const std::map<int, Literal>>());
+      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_), nullptr, nullptr,
+      SchemaNameMapper(schema_name_mapping), std::make_shared<const std::map<int, Literal>>());
 
   ArrayContainer col1_data = {
       .arrays = {OptionalVector<int32_t>{3, 1}, OptionalVector<int32_t>{4}, OptionalVector<int32_t>{9, 2, 5}}};
@@ -275,11 +275,10 @@ TEST_F(FileReaderBuilderTest, DefaultValue) {
 
   auto field_id_mapper = std::make_shared<FieldIdMapper>(std::map<int, std::string>{{1, "col1"}, {2, "col2"}});
 
-  FileReaderBuilder file_reader_builder(
-      field_ids_to_retrieve, equality_deletes_, field_id_mapper, MakeFileReaderProvider(fs_provider_),
-      nullptr, nullptr, std::nullopt,
-      std::make_shared<const std::map<int, Literal>>(
-          std::map<int, Literal>{{2, Literal(std::make_shared<arrow::Int32Scalar>(10))}}));
+  FileReaderBuilder file_reader_builder(field_ids_to_retrieve, equality_deletes_, field_id_mapper,
+                                        MakeFileReaderProvider(fs_provider_), nullptr, nullptr, std::nullopt,
+                                        std::make_shared<const std::map<int, Literal>>(std::map<int, Literal>{
+                                            {2, Literal(std::make_shared<arrow::Int32Scalar>(10))}}));
 
   auto col1_data = OptionalVector<int32_t>{1, 2, 3, 4};
   auto col2_data = OptionalVector<int32_t>{10, 10, 10, 10};
@@ -306,8 +305,7 @@ TEST_F(FileReaderBuilderTest, ColumnFirst) {
   auto field_id_mapper = std::make_shared<FieldIdMapper>(std::map<int, std::string>{{1, "col1"}, {2, "col2"}});
 
   FileReaderBuilder file_reader_builder(field_ids_to_retrieve, equality_deletes_, field_id_mapper,
-                                        MakeFileReaderProvider(fs_provider_), nullptr, nullptr,
-                                        std::nullopt,
+                                        MakeFileReaderProvider(fs_provider_), nullptr, nullptr, std::nullopt,
                                         std::make_shared<const std::map<int, Literal>>(std::map<int, Literal>{
                                             {1, Literal(std::make_shared<arrow::Int32Scalar>(2))},
                                             {2, Literal(std::make_shared<arrow::Int32Scalar>(10))}}));

--- a/iceberg/streams/ut/file_reader_test.cpp
+++ b/iceberg/streams/ut/file_reader_test.cpp
@@ -22,8 +22,8 @@ TEST(FileReader, Trivial) {
   auto column2 = MakeInt32Column("f2", 2, col2_data);
   ASSERT_OK(WriteToFile({{column1, column2}, std::vector<size_t>{1, 1, 1}}, data_path));
 
-  auto provider = std::make_shared<LocalFileReaderProvider>();
-  ASSIGN_OR_FAIL(auto input, provider->Open(data_path));
+  auto provider = MakeLocalFileReaderProvider();
+  ASSIGN_OR_FAIL(auto input, provider->OpenParquet(data_path));
 
   auto stream = std::make_shared<ParquetFileReader>(input, std::vector<int>{0, 2}, std::vector<int>{1});
 

--- a/iceberg/streams/ut/local_file_reader_provider.h
+++ b/iceberg/streams/ut/local_file_reader_provider.h
@@ -4,29 +4,17 @@
 #include <string>
 
 #include "arrow/filesystem/localfs.h"
-#include "arrow/status.h"
-#include "iceberg/common/fs/file_reader_provider.h"
-#include "parquet/arrow/reader.h"
+#include "iceberg/common/fs/file_reader_provider_impl.h"
 
 namespace iceberg {
 
-class LocalFileReaderProvider : public IFileReaderProvider {
- public:
-  arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> Open(const std::string& url) const override {
-    auto fs = std::make_shared<arrow::fs::LocalFileSystem>();
-
-    std::string path = url.starts_with("file://") ? url.substr(7) : url;
-    ARROW_ASSIGN_OR_RAISE(auto input_file, fs->OpenInputFile(path));
-
-    parquet::arrow::FileReaderBuilder reader_builder;
-    ARROW_RETURN_NOT_OK(reader_builder.Open(input_file));
-    reader_builder.memory_pool(arrow::default_memory_pool());
-
-    std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
-    ARROW_ASSIGN_OR_RAISE(arrow_reader, reader_builder.Build());
-
-    return arrow_reader;
-  }
-};
+inline std::shared_ptr<IFileReaderProvider> MakeLocalFileReaderProvider() {
+  return std::make_shared<FileReaderProvider>(
+      [](const std::string& url) -> arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> {
+        auto fs = std::make_shared<arrow::fs::LocalFileSystem>();
+        std::string path = url.starts_with("file://") ? url.substr(7) : url;
+        return fs->OpenInputFile(path);
+      });
+}
 
 }  // namespace iceberg

--- a/iceberg/streams/ut/positional_delete_applier_test.cpp
+++ b/iceberg/streams/ut/positional_delete_applier_test.cpp
@@ -64,7 +64,7 @@ class PositionalDeleteApplierTest : public ::testing::Test {
     auto fs_provider = std::make_shared<FileSystemProvider>(
         std::map<std::string, std::shared_ptr<IFileSystemGetter>>{{"file", std::make_shared<LocalFileSystemGetter>()}});
     auto positional_delete_applier = std::make_shared<PositionalDeleteApplier>(
-        input_stream, std::move(info), std::make_shared<FileReaderProvider>(fs_provider), counting_logger_);
+        input_stream, std::move(info), MakeFileReaderProvider(fs_provider), counting_logger_);
 
     std::vector<std::shared_ptr<IcebergBatch>> result_batches;
     while (true) {

--- a/iceberg/streams/ut/row_group_reader_test.cpp
+++ b/iceberg/streams/ut/row_group_reader_test.cpp
@@ -22,8 +22,8 @@ TEST(RowGroupReader, Trivial) {
   auto column2 = MakeInt32Column("f2", 2, col2_data);
   ASSERT_OK(WriteToFile({{column1, column2}, std::vector<size_t>{1, 1, 1}}, data_path));
 
-  auto provider = std::make_shared<LocalFileReaderProvider>();
-  ASSIGN_OR_FAIL(auto input, provider->Open(data_path));
+  auto provider = MakeLocalFileReaderProvider();
+  ASSIGN_OR_FAIL(auto input, provider->OpenParquet(data_path));
 
   auto stream = std::make_shared<RowGroupReader>(input, 1, std::vector<int>{1});
   auto batch = stream->ReadNext();
@@ -47,8 +47,8 @@ TEST(RowGroupReader, WithRowNumber) {
   auto column2 = MakeInt32Column("f2", 2, col2_data);
   ASSERT_OK(WriteToFile({{column1, column2}, std::vector<size_t>{1, 1, 1}}, data_path));
 
-  auto provider = std::make_shared<LocalFileReaderProvider>();
-  ASSIGN_OR_FAIL(auto input, provider->Open(data_path));
+  auto provider = MakeLocalFileReaderProvider();
+  ASSIGN_OR_FAIL(auto input, provider->OpenParquet(data_path));
 
   auto stream = std::make_shared<RowGroupReaderWithRowNumber>(input, 1, std::vector<int>{1});
   auto batch = stream->ReadNext();

--- a/tests/streams_test.cpp
+++ b/tests/streams_test.cpp
@@ -112,8 +112,8 @@ IcebergStreamPtr MakeDataStream(const std::string& path, const std::vector<int>&
 
   return IcebergScanBuilder::MakeIcebergStream(
       meta_stream, pos_del_info, std::make_shared<EqualityDeletes>(std::move(eq_del_info)), std::move(eq_del_config),
-      nullptr, nullptr, *metadata->GetCurrentSchema(), field_ids_to_retrieve,
-      std::make_shared<FileReaderProvider>(fs_provider), schema_name_mapping);
+      nullptr, nullptr, *metadata->GetCurrentSchema(), field_ids_to_retrieve, MakeFileReaderProvider(fs_provider),
+      schema_name_mapping);
 }
 
 std::shared_ptr<arrow::Scalar> CreateStringListScalar(const std::vector<std::string>& values) {


### PR DESCRIPTION
This PR refactors the IFileReaderProvider interface to improve naming clarity. Its interface will be extended in upcoming PRs.