### PR TITLE
Remove redundant curl package

### DIFF
--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: install apt deps
       run: |
         sudo apt-get -y update
-        DEBIAN_FRONTEND=noninteractive sudo apt install -y libcurl4-openssl-dev clang-format postgresql curl
+        DEBIAN_FRONTEND=noninteractive sudo apt install -y libcurl4-openssl-dev clang-format postgresql
     - name: check format
       run : |
         find . -type f -not -path './vendor/*' \( -name '*.c' -o -name '*.h' -o -name '*.cpp' -o -name '*.cc' \) -print0 | xargs -0 clang-format --dry-run -Werror


### PR DESCRIPTION
The `curl` package is already installed and does not need to be explicitly installed via apt.